### PR TITLE
feat(thrift new): 添加对于annotation的支持

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -64,6 +64,13 @@ export interface FunctionEntity {
   comment: string;
 }
 
+export interface IAnnotationConfig {
+  fieldKey?: string;
+  fieldComment?: string[];
+  functionMethod?: string;
+  functionUri?: string;
+}
+
 export interface CMDOptions {
   root: string;
   tsRoot: string;
@@ -74,4 +81,7 @@ export interface CMDOptions {
   useTag: string;
   usePrettier: boolean;
   rpcNamespace: string;
+  thriftNew?: boolean;
+  annotationConfigPath?: string;
+  annotationConfig?: IAnnotationConfig;
 }

--- a/src/thriftNew/index.ts
+++ b/src/thriftNew/index.ts
@@ -42,6 +42,17 @@ export function parser(
   if (!isThritDocument(ast)) {
     throw new Error('thrift parser error:' + filefullname);
   }
+  if (options && options.annotationConfigPath) {
+    if (fs.existsSync(options.annotationConfigPath)) {
+      try {
+        options.annotationConfig = JSON.parse(
+          fs.readFileSync(options.annotationConfigPath).toString()
+        );
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  }
 
   const rtn: RpcEntity = {
     ns: '',
@@ -196,7 +207,7 @@ function handleField(
   options: Partial<CMDOptions> = {}
 ): IhandleField {
   let name = field.name.value;
-  const comment = handleComments(field.comments);
+  let comment = handleComments(field.comments);
   // 需要处理typedef
   const type = getFieldTypeString(field.fieldType);
   const index = field.fieldID ? field.fieldID.value : 0;
@@ -224,6 +235,30 @@ function handleField(
           name = match[1];
         }
       }
+    }
+  }
+  // annotation config 优先级高于useTag
+  if (options && options.annotationConfig) {
+    const { fieldComment, fieldKey } = options.annotationConfig;
+    if (
+      field.annotations &&
+      Array.isArray(field.annotations.annotations) &&
+      (Array.isArray(fieldComment) || fieldKey)
+    ) {
+      field.annotations.annotations.forEach(annotation => {
+        if (Array.isArray(fieldComment)) {
+          if (fieldComment.indexOf(annotation.name.value) > -1) {
+            comment += `\t\t${annotation.name.value}:${
+              annotation!.value!.value
+            }`;
+          }
+        }
+        if (fieldKey) {
+          if (annotation.name.value === fieldKey) {
+            name = annotation!.value!.value;
+          }
+        }
+      });
     }
   }
   const defaultValue = '';
@@ -261,7 +296,27 @@ function handleFunction(
       name
     };
   });
-  const comment = handleComments(func.comments);
+  let comment = handleComments(func.comments);
+  if (options && options.annotationConfig) {
+    // 根据annotation生成config
+    const { functionMethod, functionUri } = options.annotationConfig;
+    if (functionMethod || functionUri) {
+      if (func.annotations && Array.isArray(func.annotations.annotations)) {
+        func.annotations.annotations.forEach(annotation => {
+          if (functionMethod) {
+            if (annotation.name.value === functionMethod) {
+              comment += `\t\t@method: ${annotation!.value!.value}`;
+            }
+          }
+          if (functionUri) {
+            if (annotation.name.value === functionUri) {
+              comment += `\t\t@uri: ${annotation!.value!.value}`;
+            }
+          }
+        });
+      }
+    }
+  }
   return {
     returnType,
     inputParams,

--- a/test/thriftNew/annotationConfig.json
+++ b/test/thriftNew/annotationConfig.json
@@ -1,0 +1,6 @@
+{
+  "fieldKey": "key",
+  "fieldComment": ["source"],
+  "functionMethod": "method",
+  "functionUri": "uri"
+}

--- a/test/thriftNew/examples/annotation.thrift
+++ b/test/thriftNew/examples/annotation.thrift
@@ -1,0 +1,9 @@
+namespace go life.api_favorite
+
+struct Collection {
+    1: optional BizType biz_type (source = 'query',   key = 'bizType'),
+    3: optional pack_goods.ExtensiveGoodsItem sku_collection,
+}
+service CollectService {
+  Collection Collect(1:i32 req)  (method = 'GET',  uri = '/api/collect'),
+}

--- a/test/thriftNew/readCode.test.ts
+++ b/test/thriftNew/readCode.test.ts
@@ -219,16 +219,45 @@ describe('thrift - read code file', () => {
     const res = await readCode(
       path.resolve(__dirname, './examples/client.thrift'),
       {
-        useTag: 'go'
+        useTag: 'go',
+        annotationConfig: {}
       }
     );
     const res2 = await readCode(
       path.resolve(__dirname, './examples/client.thrift'),
       {
-        useTag: 'js'
+        useTag: 'js',
+        annotationConfig: {}
       }
     );
     expect(res.interfaces[0].properties.biz_type_go).not.eq(undefined);
     expect(res2.interfaces[0].properties.biz_type_go).eq(undefined);
+  });
+
+  it('support annotation config', async () => {
+    const thirftCode = `
+      struct Collection {
+        1: optional BizType biz_type (source = 'query',   key = 'bizType'),
+        3: optional pack_goods.ExtensiveGoodsItem sku_collection,
+    }
+    service CollectService {
+      Collection Collect(1:i32 req)  (method = 'GET',  uri = '/api/collect'),
+  }
+      `;
+    const res = await parser('', thirftCode, {
+      annotationConfig: {
+        fieldKey: 'key',
+        fieldComment: ['source'],
+        functionMethod: 'method',
+        functionUri: 'uri'
+      }
+    });
+    expect(res.interfaces[0].properties['bizType'].index).to.eq(1);
+    expect(res.interfaces[0].properties['bizType'].comment).to.eq(
+      '\t\tsource:query'
+    );
+    expect(res.services[0].interfaces['Collect'].comment).to.eq(
+      '\t\t@method: GET\t\t@uri: /api/collect'
+    );
   });
 });


### PR DESCRIPTION
annotation具体支持

- 支持struct中FieldDefinition的key参数，用于覆盖FieldDefinition.name.value
- 支持struct中FieldDefinition的其他参数，用于生成注释
- 支持service中的FunctionDefinition的method，uri等参数，用于生成注释，后续可以用于自动生成