### PR TITLE
feat(thrift new): 添加对于annotation的支持

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -4,8 +4,8 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import glob from 'glob';
 import { RpcEntity, CMDOptions } from './interfaces';
-import { readCode as readCodeNew } from './thriftNew/index';
 import { readCode } from './thrift/readCode';
+import { readCode as readCodeNew } from './thriftNew';
 import { print, printCollectionRpc } from './thrift/print';
 import combine from './tools/combine';
 import { updateNotify } from './tools/updateNotify';
@@ -23,6 +23,10 @@ commander
   .option('-p, --project [dir]', 'thrift 根目录，默认为当前目录', process.cwd())
   .option('-an, --auto-namespace', '是否使用文件夹路径作为 namespace')
   .option('-s --strict', '如果字段没有指定 required 视为 optional')
+  .option(
+    '-ac --annotation-config <annotationConfig>',
+    '额外的json配置文件，用来读取annotation配置'
+  )
   .option('--timestamp', '在头部加上生成时间')
   .option('-e --entry [filename]', '指定入口文件名', 'index.d.ts')
   .option('--use-tag <tagName>', '使用 tag 名称替换 field 名称')
@@ -52,7 +56,8 @@ const options: CMDOptions = {
   usePrettier: commander.prettier,
   rpcNamespace: commander.rpcNamespace,
   lint: false,
-  i64_as_number: false
+  i64_as_number: false,
+  annotationConfigPath: path.resolve(process.cwd(), commander.annotationConfig)
 };
 fs.ensureDirSync(options.tsRoot);
 fs.copyFileSync(

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -67,6 +67,13 @@ export interface FunctionEntity {
   comment: string;
 }
 
+export interface IAnnotationConfig {
+  fieldKey?: string;
+  fieldComment?: string[];
+  functionMethod?: string;
+  functionUri?: string;
+}
+
 export interface CMDOptions {
   root: string;
   tsRoot: string;
@@ -79,6 +86,8 @@ export interface CMDOptions {
   rpcNamespace: string;
   lint: boolean;
   i64_as_number: boolean;
+  annotationConfigPath?: string;
+  annotationConfig?: IAnnotationConfig;
 }
 
 export type PbNodeEntity = (

--- a/test/thriftNew/annotationConfig.json
+++ b/test/thriftNew/annotationConfig.json
@@ -1,0 +1,6 @@
+{
+  "fieldKey": "key",
+  "fieldComment": ["source"],
+  "functionMethod": "method",
+  "functionUri": "uri"
+}

--- a/test/thriftNew/examples/annotation.thrift
+++ b/test/thriftNew/examples/annotation.thrift
@@ -1,0 +1,9 @@
+namespace go life.api_favorite
+
+struct Collection {
+    1: optional BizType biz_type (source = 'query',   key = 'bizType'),
+    3: optional pack_goods.ExtensiveGoodsItem sku_collection,
+}
+service CollectService {
+  Collection Collect(1:i32 req)  (method = 'GET',  uri = '/api/collect'),
+}

--- a/test/thriftNew/readCode.test.ts
+++ b/test/thriftNew/readCode.test.ts
@@ -219,16 +219,45 @@ describe('thrift - read code file', () => {
     const res = await readCode(
       path.resolve(__dirname, './examples/client.thrift'),
       {
-        useTag: 'go'
+        useTag: 'go',
+        annotationConfig: {}
       }
     );
     const res2 = await readCode(
       path.resolve(__dirname, './examples/client.thrift'),
       {
-        useTag: 'js'
+        useTag: 'js',
+        annotationConfig: {}
       }
     );
     expect(res.interfaces[0].properties.biz_type_go).not.eq(undefined);
     expect(res2.interfaces[0].properties.biz_type_go).eq(undefined);
+  });
+
+  it('support annotation config', async () => {
+    const thirftCode = `
+      struct Collection {
+        1: optional BizType biz_type (source = 'query',   key = 'bizType'),
+        3: optional pack_goods.ExtensiveGoodsItem sku_collection,
+    }
+    service CollectService {
+      Collection Collect(1:i32 req)  (method = 'GET',  uri = '/api/collect'),
+  }
+      `;
+    const res = await parser('', thirftCode, {
+      annotationConfig: {
+        fieldKey: 'key',
+        fieldComment: ['source'],
+        functionMethod: 'method',
+        functionUri: 'uri'
+      }
+    });
+    expect(res.interfaces[0].properties['bizType'].index).to.eq(1);
+    expect(res.interfaces[0].properties['bizType'].comment).to.eq(
+      '\t\tsource:query'
+    );
+    expect(res.services[0].interfaces['Collect'].comment).to.eq(
+      '\t\t@method: GET\t\t@uri: /api/collect'
+    );
   });
 });


### PR DESCRIPTION
测试命令```node ./bin/dts-from-thrift --new -p ./test/thriftNew/examples/ -o ./test/out/ --annotation-config ./test/thriftNew/annotationConfig.json ```

annotation具体支持

- 支持struct中FieldDefinition的key参数，用于覆盖FieldDefinition.name.value
- 支持struct中FieldDefinition的其他参数，用于生成注释
- 支持service中的FunctionDefinition的method，uri等参数，用于生成注释，后续可以用于自动生成
