### PR TITLE
feat(support strict response): 支持--strict-response

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -31,6 +31,10 @@ commander
   .option('-an, --auto-namespace', '是否使用文件夹路径作为 namespace')
   .option('-s --strict', '如果字段没有指定 required 视为 optional')
   .option(
+    '--strict-response',
+    '在名称包含 Response 的Struct中具有default value的字段不为optional'
+  )
+  .option(
     '-ac --annotation-config <annotationConfig>',
     '额外的json配置文件，用来读取annotation配置'
   )
@@ -81,7 +85,8 @@ const options: CMDOptions = {
   i64_as_number: false,
   annotationConfigPath: commander.annotationConfig
     ? path.resolve(process.cwd(), commander.annotationConfig || '')
-    : undefined
+    : undefined,
+  strictRes: commander.strictResponse
 };
 fs.ensureDirSync(options.tsRoot);
 fs.copyFileSync(

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -88,6 +88,7 @@ export interface CMDOptions {
   i64_as_number: boolean;
   annotationConfigPath?: string;
   annotationConfig?: IAnnotationConfig;
+  strictRes?: boolean;
 }
 
 export type PbNodeEntity = (

--- a/src/thriftNew/interfaces.ts
+++ b/src/thriftNew/interfaces.ts
@@ -100,6 +100,7 @@ export interface CMDOptions {
   i64_as_number: boolean;
   annotationConfigPath?: string;
   annotationConfig?: IAnnotationConfig;
+  strictRes?: boolean;
 }
 
 export type PbNodeEntity = (

--- a/test/thriftNew/readCode.test.ts
+++ b/test/thriftNew/readCode.test.ts
@@ -641,4 +641,28 @@ describe('thrift - read code file', () => {
     expect(res4.ns).to.eq('yy');
     expect(res5.ns).to.eq(undefined);
   });
+
+  it('support strict response', async () => {
+    const thirftCodeJS = `
+      struct CollectionResponse {
+        1: required i64 collection = 1,
+        1: i64 collection1 = 1,
+        1: optional i64 collection2 = 1,
+      }
+      struct CollectionRequest {
+        1: i64 collection = 1,
+        1: optional i64 collection1 = 1,
+        1: required i64 collection2 = 1,
+      }
+      `;
+    const res1 = await parser('', thirftCodeJS, { strictRes: true });
+    const collectionResponse = res1.interfaces[0].properties;
+    const collectionRequest = res1.interfaces[1].properties;
+    expect(collectionResponse.collection.optional).to.eq(false);
+    expect(collectionResponse.collection1.optional).to.eq(false);
+    expect(collectionResponse.collection2.optional).to.eq(true);
+    expect(collectionRequest.collection.optional).to.eq(true);
+    expect(collectionRequest.collection1.optional).to.eq(true);
+    expect(collectionRequest.collection2.optional).to.eq(false);
+  });
 });


### PR DESCRIPTION
在生成时开启--strict-response选项，则在判断字段的optional的时候：
1. 如果字段是reuqred，则其optional为false
2. 如果字段所在的Struct的name包含response
如果有default value且没有optional标记，则其optional为false
详见test/thriftNew/readCode.test.ts