### PR TITLE
Dev strict request

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ __运行(exec)：__`dts-from-thrift -p ~/git/my-thrift-repo/thrift -o ~/git/my-t
 
 # 变更历史（ChangeLog)
 
+## 1.0.0-rc.10 - 2019.9.8
+
+针对struct中的field是否是optional进行了梳理，详见`test/thriftNew/readCode.test.ts` line649 和下表，主要是针对`/\w+Response/i`和`/\w+Request/i`做了特殊处理，以符合实际的idl语义
+
+| 是否可选                             | requeird | 无（默认）           | optional |
+| ------------------------------------ | -------- | ------------ | -------- |
+| *response                            | false    | false        | true     |
+| *response & defualt value            | False    | false        | true     |
+| *request                             | false    | false\|true* | true     |
+| *request & default value             | false    | true         | true     |
+| Use-strict                           | false    | true         | true     |
+| No-use-strict                        | false    | false        | true     |
+| [^request\|response] & Default value | false    | true         | true     |
+
+"*"表示需要标记`strict-request`开启，表示是业务定制
+
 ## 1.0.0-rc.6 - 2019.8.19
 
 ### Added

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -32,8 +32,8 @@ commander
   .option('-an, --auto-namespace', '是否使用文件夹路径作为 namespace')
   .option('-s --strict', '如果字段没有指定 required 视为 optional')
   .option(
-    '--strict-response',
-    '在名称包含 Response 的Struct中具有default value的字段不为optional'
+    '--strict-request',
+    '在名称包含 Request 的 Struct 中如果字段没有指定 required 视为 optional'
   )
   .option(
     '-ac --annotation-config <annotationConfig>',
@@ -88,7 +88,7 @@ const options: CMDOptions = {
   annotationConfigPath: commander.annotationConfig
     ? path.resolve(process.cwd(), commander.annotationConfig || '')
     : undefined,
-  strictRes: commander.strictResponse,
+  strictReq: commander.strictRequest,
   enumJson: commander.enumJson || 'enums.json'
 };
 fs.ensureDirSync(options.tsRoot);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -88,7 +88,7 @@ export interface CMDOptions {
   i64_as_number: boolean;
   annotationConfigPath?: string;
   annotationConfig?: IAnnotationConfig;
-  strictRes?: boolean;
+  strictReq?: boolean;
   enumJson?: string;
 }
 

--- a/src/thriftNew/index.ts
+++ b/src/thriftNew/index.ts
@@ -317,12 +317,6 @@ function handleField(
   if (!isUndefined(defaultValue)) {
     if (field.requiredness === 'required') {
       optional = false;
-    } else if (
-      options.strictRes &&
-      /response/i.test(structName) &&
-      field.requiredness !== 'optional'
-    ) {
-      optional = false;
     } else {
       // 如果有默认值或指定 optional
       optional = true;
@@ -340,6 +334,14 @@ function handleField(
     });
   } else {
     defaultValue = '';
+  }
+
+  if (
+    options.strictReq &&
+    /request/i.test(structName) &&
+    field.requiredness !== 'required'
+  ) {
+    optional = true;
   }
 
   return {

--- a/src/thriftNew/index.ts
+++ b/src/thriftNew/index.ts
@@ -310,18 +310,33 @@ function handleField(
     }
   }
 
-  let optional = options.useStrictMode
-    ? field.requiredness !== 'required'
-    : !(field.requiredness !== 'optional');
+  let optional = false;
+  if (field.requiredness === 'required') {
+    optional = false;
+  } else if (field.requiredness === 'optional') {
+    optional = true;
+  } else {
+    const isRes = /response/i.test(structName);
+    const isReq = /request/i.test(structName);
+    const useStrict = options.useStrictMode;
+    const useStrictReq = options.strictReq;
+    const hasDefault = !isUndefined(defaultValue);
 
-  if (!isUndefined(defaultValue)) {
-    if (field.requiredness === 'required') {
-      optional = false;
-    } else {
-      // 如果有默认值或指定 optional
+    if (useStrict) {
       optional = true;
     }
+    if (isReq && useStrictReq) {
+      optional = true;
+    }
+    if (isReq && hasDefault) {
+      optional = true;
+    }
+    if (!isRes && !isReq && hasDefault) {
+      optional = true;
+    }
+  }
 
+  if (!isUndefined(defaultValue)) {
     let value = defaultValue;
     if (defaultValue === '') {
       value = '""';
@@ -334,14 +349,6 @@ function handleField(
     });
   } else {
     defaultValue = '';
-  }
-
-  if (
-    options.strictReq &&
-    /request/i.test(structName) &&
-    field.requiredness !== 'required'
-  ) {
-    optional = true;
   }
 
   return {

--- a/src/thriftNew/interfaces.ts
+++ b/src/thriftNew/interfaces.ts
@@ -100,7 +100,7 @@ export interface CMDOptions {
   i64_as_number: boolean;
   annotationConfigPath?: string;
   annotationConfig?: IAnnotationConfig;
-  strictRes?: boolean;
+  strictReq?: boolean;
   enumJson?: string;
 }
 

--- a/test/thriftNew/readCode.test.ts
+++ b/test/thriftNew/readCode.test.ts
@@ -664,6 +664,14 @@ describe('thrift - read code file', () => {
         1: i64 collectionD1 = 1,
         1: optional i64 collectionD2 = 1,
       }
+      struct Collection {
+        1: required i64 collection,
+        1: i64 collection1,
+        1: optional i64 collection2,
+        1: required i64 collectionD = 1,
+        1: i64 collectionD1 = 1,
+        1: optional i64 collectionD2 = 1,
+      }
       `;
     /**
      * 影响optional的元素
@@ -676,11 +684,12 @@ describe('thrift - read code file', () => {
     });
     const collectionResponse = res1.interfaces[0].properties;
     const collectionRequest = res1.interfaces[1].properties;
+    const collection = res1.interfaces[2].properties;
     expect(collectionResponse.collection.optional).to.eq(false);
     expect(collectionResponse.collection1.optional).to.eq(false);
     expect(collectionResponse.collection2.optional).to.eq(true);
     expect(collectionResponse.collectionD.optional).to.eq(false);
-    expect(collectionResponse.collectionD1.optional).to.eq(true);
+    expect(collectionResponse.collectionD1.optional).to.eq(false);
     expect(collectionResponse.collectionD2.optional).to.eq(true);
     expect(collectionRequest.collection.optional).to.eq(false);
     expect(collectionRequest.collection1.optional).to.eq(true);
@@ -688,5 +697,11 @@ describe('thrift - read code file', () => {
     expect(collectionRequest.collectionD.optional).to.eq(false);
     expect(collectionRequest.collectionD1.optional).to.eq(true);
     expect(collectionRequest.collectionD2.optional).to.eq(true);
+    expect(collection.collection.optional).to.eq(false);
+    expect(collection.collection1.optional).to.eq(false);
+    expect(collection.collection2.optional).to.eq(true);
+    expect(collection.collectionD.optional).to.eq(false);
+    expect(collection.collectionD1.optional).to.eq(true);
+    expect(collection.collectionD2.optional).to.eq(true);
   });
 });

--- a/test/thriftNew/readCode.test.ts
+++ b/test/thriftNew/readCode.test.ts
@@ -649,24 +649,44 @@ describe('thrift - read code file', () => {
   it('support strict response', async () => {
     const thirftCodeJS = `
       struct CollectionResponse {
-        1: required i64 collection = 1,
-        1: i64 collection1 = 1,
-        1: optional i64 collection2 = 1,
+        1: required i64 collection,
+        1: i64 collection1,
+        1: optional i64 collection2,
+        1: required i64 collectionD = 1,
+        1: i64 collectionD1 = 1,
+        1: optional i64 collectionD2 = 1,
       }
       struct CollectionRequest {
-        1: i64 collection = 1,
-        1: optional i64 collection1 = 1,
-        1: required i64 collection2 = 1,
+        1: required i64 collection,
+        1: i64 collection1,
+        1: optional i64 collection2,
+        1: required i64 collectionD = 1,
+        1: i64 collectionD1 = 1,
+        1: optional i64 collectionD2 = 1,
       }
       `;
-    const res1 = await parser('', thirftCodeJS, { strictRes: true });
+    /**
+     * 影响optional的元素
+     * - required/optional/无前缀
+     * - default value
+     * - 处于request/reponse的结构体中
+     */
+    const res1 = await parser('', thirftCodeJS, {
+      strictReq: true
+    });
     const collectionResponse = res1.interfaces[0].properties;
     const collectionRequest = res1.interfaces[1].properties;
     expect(collectionResponse.collection.optional).to.eq(false);
     expect(collectionResponse.collection1.optional).to.eq(false);
     expect(collectionResponse.collection2.optional).to.eq(true);
-    expect(collectionRequest.collection.optional).to.eq(true);
+    expect(collectionResponse.collectionD.optional).to.eq(false);
+    expect(collectionResponse.collectionD1.optional).to.eq(true);
+    expect(collectionResponse.collectionD2.optional).to.eq(true);
+    expect(collectionRequest.collection.optional).to.eq(false);
     expect(collectionRequest.collection1.optional).to.eq(true);
-    expect(collectionRequest.collection2.optional).to.eq(false);
+    expect(collectionRequest.collection2.optional).to.eq(true);
+    expect(collectionRequest.collectionD.optional).to.eq(false);
+    expect(collectionRequest.collectionD1.optional).to.eq(true);
+    expect(collectionRequest.collectionD2.optional).to.eq(true);
   });
 });


### PR DESCRIPTION
针对struct中的field是否是optional进行了梳理，详见`test/thriftNew/readCode.test.ts` line649 和下表，主要是针对`/\w+Response/i`和`/\w+Request/i`做了特殊处理，以符合实际的idl语义

 | 是否可选                             | requeird | 无（默认）           | optional |
| ------------------------------------ | -------- | ------------ | -------- |
| *response                            | false    | false        | true     |
| *response & defualt value            | False    | false        | true     |
| *request                             | false    | false\|true* | true     |
| *request & default value             | false    | true         | true     |
| Use-strict                           | false    | true         | true     |
| No-use-strict                        | false    | false        | true     |
| [^request\|response] & Default value | false    | true         | true     |

 "*"表示需要标记`strict-request`开启，表示是业务定制