### PR TITLE
Dev i64 const map

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,33 +4,51 @@
 
 thrift RPC 定义文件转 d.ts 工具
 
-__安装(install)：__ `npm install dts-from-thrift -g`
+**安装(install)：** `npm install dts-from-thrift -g`
 
-__运行(exec)：__`dts-from-thrift -p ~/git/my-thrift-repo/thrift -o ~/git/my-ts-repo/typings`
+**运行(exec)：**`dts-from-thrift -p ~/git/my-thrift-repo/thrift -o ~/git/my-ts-repo/typings`
 
 由于实现全靠正则，特殊 case 无法避免，可以提 issue 或者 PR。
 
 (The tool use RegExp to generate d.ts file. If some special statement cases causes bugs, an issue or a PR is welcome.)
 
-
-
 # 变更历史（ChangeLog)
+
+## 1.0.0-rc.11 - 2019.10.16
+
+支持在 thrift 中把 i64 转换成 string 或者内置的 Int64 对象，在`--new`的同时通过`--i64`设置，默认生成 int64 类型。例如 i64 生成 string 类型
+
+```shell
+node ./bin/dts-from-thrift -p ./test/thriftNew/examples/ \
+-o ./test/thriftNew/out/ \
+--new --i64 string
+```
+
+支持把 thrift idl 中的 const 输出到 d.ts 和 enum.json 中，用于类型提示或者自定义 babel 插件。注意：d.ts 中的 const 在编译过程中并不会被转换。效果可以运行根目录下的 run.sh 来查看。
+
+支持 thrift idl 中的 `map<typea, typeb>` 输出到 `Record<string, typeb>`。注意：Record 对于 key 的支持只有 number,string,symbol，所以`typea`强制为`string`。栗子：
+
+```shell
+node ./bin/dts-from-thrift -p ./test/thriftNew/examples/ \
+-o ./test/thriftNew/out/ \
+--new --i64 string --map Record
+```
 
 ## 1.0.0-rc.10 - 2019.9.8
 
-针对struct中的field是否是optional进行了梳理，详见`test/thriftNew/readCode.test.ts` line649 和下表，主要是针对`/\w+Response/i`和`/\w+Request/i`做了特殊处理，以符合实际的idl语义
+针对 struct 中的 field 是否是 optional 进行了梳理，详见`test/thriftNew/readCode.test.ts` line649 和下表，主要是针对`/\w+Response/i`和`/\w+Request/i`做了特殊处理，以符合实际的 idl 语义
 
-| 是否可选                             | requeird | 无（默认）           | optional |
-| ------------------------------------ | -------- | ------------ | -------- |
-| *response                            | false    | false        | true     |
-| *response & defualt value            | False    | false        | true     |
-| *request                             | false    | false\|true* | true     |
-| *request & default value             | false    | true         | true     |
-| Use-strict                           | false    | true         | true     |
-| No-use-strict                        | false    | false        | true     |
-| [^request\|response] & Default value | false    | true         | true     |
+| 是否可选                             | requeird | 无（默认）    | optional |
+| ------------------------------------ | -------- | ------------- | -------- |
+| \*response                           | false    | false         | true     |
+| \*response & defualt value           | False    | false         | true     |
+| \*request                            | false    | false\|true\* | true     |
+| \*request & default value            | false    | true          | true     |
+| Use-strict                           | false    | true          | true     |
+| No-use-strict                        | false    | false         | true     |
+| [^request\|response] & Default value | false    | true          | true     |
 
-"*"表示需要标记`strict-request`开启，表示是业务定制
+"\*"表示需要标记`strict-request`开启，表示是业务定制
 
 ## 1.0.0-rc.6 - 2019.8.19
 
@@ -46,7 +64,7 @@ __运行(exec)：__`dts-from-thrift -p ~/git/my-thrift-repo/thrift -o ~/git/my-t
       255: optional i32 err_no (defaultValue=0);
   }
   */
-  
+
   interface CreateResponse {
     err_no: number; // 不指定的时候是 err_no?: number;
   }
@@ -117,7 +135,6 @@ __运行(exec)：__`dts-from-thrift -p ~/git/my-thrift-repo/thrift -o ~/git/my-t
 
   typedef generic type fix
 
-
 ## 0.8 - 2018.11.26
 
 ### Added
@@ -141,7 +158,7 @@ __运行(exec)：__`dts-from-thrift -p ~/git/my-thrift-repo/thrift -o ~/git/my-t
   	// 生成的 rpc 定义文件 (the rpc definition file name)
   ```
 
-  使用 \_Summary_ 继承 rpc 接口 (use \_Summary_ to extends)
+  使用 \_Summary* 继承 rpc 接口 (use \_Summary* to extends)
 
   ```typescript
   interface MyRPCContainer extends demo.rpc._Summary_ {}
@@ -166,24 +183,22 @@ __运行(exec)：__`dts-from-thrift -p ~/git/my-thrift-repo/thrift -o ~/git/my-t
   service RpcService {
       ResponseType interface1 (1: RequestType req);
   }
-  
+
   // generate code
   export interface RpcService {
       interface1(req: RequestType): Promise<ResponseType>;
   }
   ```
 
-
-
 ## 0.5
 
 ### Added
 
-  - dts-from-protobuf 支持
+- dts-from-protobuf 支持
 
-     (add dts-from-protobuf CLI, support protobuf)
+  (add dts-from-protobuf CLI, support protobuf)
 
-     `dts-from-protobuf -p <protobuf_idl_dir> -o <output_dir>`
+  `dts-from-protobuf -p <protobuf_idl_dir> -o <output_dir>`
 
 ## 0.4
 
@@ -197,12 +212,12 @@ __运行(exec)：__`dts-from-thrift -p ~/git/my-thrift-repo/thrift -o ~/git/my-t
   struct Foo {
     1: list<string> comments (go.tag="json:\\"list,omitempty\\""),
   }
-  
+
   // before 0.4.0
   interface Foo {
     comments: string[];
   }
-  
+
   // after 0.4.0 with [--use-tag go]
   interface Foo {
     list: string[];
@@ -214,4 +229,4 @@ __运行(exec)：__`dts-from-thrift -p ~/git/my-thrift-repo/thrift -o ~/git/my-t
 
 - codestyle: 生成文件增加 `// prettier-ignore` 避免 format 导致的 git 提交
 
-   (add `// prettier-ignore` at head of d.ts file to prevent useless git commit)
+  (add `// prettier-ignore` at head of d.ts file to prevent useless git commit)

--- a/run.sh
+++ b/run.sh
@@ -2,4 +2,5 @@ rm -rf ./test/thriftNew/out/ && yarn build && \
 # dts-from-thrift -V
 node ./bin/dts-from-thrift -p ./test/thriftNew/examples/ \
 -o ./test/thriftNew/out/ \
- -e reference.d.ts --use-tag=go --enum-json  --strict-request --rpc-namespace=anote.rpc --new
+ -e reference.d.ts --use-tag=go --enum-json  --strict-request --rpc-namespace=anote.rpc --new \
+ --map Record --i64 string

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,5 @@
+rm -rf ./test/thriftNew/out/ && yarn build && \
+# dts-from-thrift -V
+node ./bin/dts-from-thrift -p ./test/thriftNew/examples/ \
+-o ./test/thriftNew/out/ \
+ -e reference.d.ts --use-tag=go --enum-json  --strict-request --rpc-namespace=anote.rpc --new

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -36,6 +36,10 @@ commander
     '设置 i64 的转化类型。默认为“Int64”，可选string'
   )
   .option(
+    '-map --map [mapType]',
+    '设置 map 的转化类型。默认为“Map”，可选Record'
+  )
+  .option(
     '--strict-request',
     '在名称包含 Request 的 Struct 中如果字段没有指定 required 视为 optional'
   )
@@ -94,7 +98,8 @@ const options: CMDOptions = {
     : undefined,
   strictReq: commander.strictRequest,
   enumJson: commander.enumJson || 'enums.json',
-  i64Type: commander.i64 === 'string' ? 'string' : 'Int64'
+  i64Type: commander.i64 === 'string' ? 'string' : 'Int64',
+  mapType: commander.map === 'Record' ? 'Record' : 'Map'
 };
 fs.ensureDirSync(options.tsRoot);
 fs.copyFileSync(

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -17,6 +17,7 @@ import {
 } from './thriftNew/print';
 import combine from './tools/combine';
 import { updateNotify } from './tools/updateNotify';
+import { replaceTsHelperInt64 } from './tools/utils';
 import { ServiceEntity } from './interfaces';
 import { prettier } from './tools/format';
 
@@ -106,6 +107,9 @@ fs.copyFileSync(
   path.join(__dirname, 'tools/tsHelper.d.ts'),
   path.join(options.tsRoot, 'tsHelper.d.ts')
 );
+if (options.i64Type === 'string') {
+  replaceTsHelperInt64(path.join(options.tsRoot, 'tsHelper.d.ts'));
+}
 
 const thriftFiles = glob
   .sync('**/*.thrift', { cwd: options.root })

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -32,6 +32,10 @@ commander
   .option('-an, --auto-namespace', '是否使用文件夹路径作为 namespace')
   .option('-s --strict', '如果字段没有指定 required 视为 optional')
   .option(
+    '-i64 --i64 [i64Type]',
+    '设置 i64 的转化类型。默认为“Int64”，可选string'
+  )
+  .option(
     '--strict-request',
     '在名称包含 Request 的 Struct 中如果字段没有指定 required 视为 optional'
   )
@@ -89,7 +93,8 @@ const options: CMDOptions = {
     ? path.resolve(process.cwd(), commander.annotationConfig || '')
     : undefined,
   strictReq: commander.strictRequest,
-  enumJson: commander.enumJson || 'enums.json'
+  enumJson: commander.enumJson || 'enums.json',
+  i64Type: commander.i64 === 'string' ? 'string' : 'Int64'
 };
 fs.ensureDirSync(options.tsRoot);
 fs.copyFileSync(

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -91,6 +91,7 @@ export interface CMDOptions {
   strictReq?: boolean;
   enumJson?: string;
   i64Type?: string;
+  mapType?: string;
 }
 
 export type PbNodeEntity = (

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -90,6 +90,7 @@ export interface CMDOptions {
   annotationConfig?: IAnnotationConfig;
   strictReq?: boolean;
   enumJson?: string;
+  i64Type?: string;
 }
 
 export type PbNodeEntity = (

--- a/src/thriftNew/index.ts
+++ b/src/thriftNew/index.ts
@@ -7,7 +7,11 @@ import {
   FunctionType,
   FieldDefinition,
   FunctionDefinition,
-  EnumDefinition
+  EnumDefinition,
+  ConstDefinition,
+  DoubleConstant,
+  IntConstant,
+  StringLiteral
 } from './@creditkarma/thrift-parser';
 import {
   RpcEntity,
@@ -18,7 +22,9 @@ import {
   ServiceEntity,
   FunctionEntity,
   EnumEntity,
-  EnumEntityMember
+  EnumEntityMember,
+  ConstantEntity,
+  ConstantEntityType
 } from './interfaces';
 import { handleComments } from './handleComments';
 import * as fs from 'fs-extra';
@@ -63,7 +69,8 @@ export function parser(
     interfaces: [],
     enums: [],
     typeDefs: [],
-    services: []
+    services: [],
+    consts: []
   };
 
   const namespaces: { [key: string]: string } = {};
@@ -117,7 +124,7 @@ export function parser(
         loc: ts.loc
       };
       aTypeDef.alias = ts.name.value;
-      aTypeDef.type = getFieldTypeString(ts.definitionType);
+      aTypeDef.type = getFieldTypeString(ts.definitionType, options);
       rtn.typeDefs.push(aTypeDef);
     }
 
@@ -144,7 +151,10 @@ export function parser(
 
     // const 考虑支持
     if (ts.type === SyntaxType.ConstDefinition) {
-      //
+      const temp = handleConst(ts);
+      if (temp !== false) {
+        rtn.consts.push(temp);
+      }
     }
   });
 
@@ -176,13 +186,17 @@ export function transformAst(ast: ThriftDocument): RpcEntity {
   return {} as any;
 }
 
-function getFieldTypeString(fieldType: FunctionType): string {
+function getFieldTypeString(
+  fieldType: FunctionType,
+  options: Partial<CMDOptions> = {}
+): string {
+  const { i64Type = 'Int64' } = options;
   const ThriftType2JavascriptType: { [key: string]: string } = {
     [SyntaxType.BoolKeyword]: 'boolean',
     [SyntaxType.ByteKeyword]: 'number',
     [SyntaxType.I16Keyword]: 'number',
     [SyntaxType.I32Keyword]: 'number',
-    [SyntaxType.I64Keyword]: 'Int64',
+    [SyntaxType.I64Keyword]: i64Type,
     [SyntaxType.DoubleKeyword]: 'number',
     [SyntaxType.StringKeyword]: 'string',
     [SyntaxType.BinaryKeyword]: 'any',
@@ -193,19 +207,21 @@ function getFieldTypeString(fieldType: FunctionType): string {
     [SyntaxType.VoidKeyword]: 'void'
   };
 
-  if (fieldType.type === SyntaxType.Identifier) {
-    return fieldType.value;
-  }
+  if (options)
+    if (fieldType.type === SyntaxType.Identifier) {
+      return fieldType.value;
+    }
   if (fieldType.type === SyntaxType.SetType) {
-    return `Set<${getFieldTypeString(fieldType.valueType)}>`;
+    return `Set<${getFieldTypeString(fieldType.valueType, options)}>`;
   }
   if (fieldType.type === SyntaxType.ListType) {
-    return `${getFieldTypeString(fieldType.valueType)}[]`;
+    return `${getFieldTypeString(fieldType.valueType, options)}[]`;
   }
   if (fieldType.type === SyntaxType.MapType) {
-    return `Map<${getFieldTypeString(fieldType.keyType)}, ${getFieldTypeString(
-      fieldType.valueType
-    )}>`;
+    return `Map<${getFieldTypeString(
+      fieldType.keyType,
+      options
+    )}, ${getFieldTypeString(fieldType.valueType, options)}>`;
   }
   return ThriftType2JavascriptType[fieldType.type];
 }
@@ -223,7 +239,7 @@ function handleField(
   let name = field.name.value;
   const commentsBefore = field.commentsBefore || [];
   // 需要处理typedef
-  const type = getFieldTypeString(field.fieldType);
+  const type = getFieldTypeString(field.fieldType, options);
   const index = field.fieldID ? field.fieldID.value : 0;
   // 考虑多种type数据的default value StringLiteral | IntConstant | DoubleConstant | BooleanLiteral | ConstMap | ConstList | Identifier
   let defaultValue: string | undefined;
@@ -379,7 +395,7 @@ function handleFunction(
   func: FunctionDefinition,
   options?: Partial<CMDOptions> | undefined
 ): FunctionEntity {
-  const returnType = getFieldTypeString(func.returnType);
+  const returnType = getFieldTypeString(func.returnType, options);
   const inputParams = func.fields.map((field: any) => {
     const { entity: temp, name } = handleField(field, options);
     return {
@@ -440,6 +456,51 @@ function handleFunction(
     loc: func.loc,
     commentsBefore,
     commentsAfter: func.commentsAfter
+  };
+}
+
+function handleConst(
+  c: ConstDefinition,
+  options?: CMDOptions
+): ConstantEntity | false {
+  let cType;
+  let value;
+  const constType = c.fieldType.type;
+  if (
+    c.name.value === 'liuqi' &&
+    (c.initializer as IntConstant).value.value === '1995'
+  ) {
+    return false;
+  }
+  if (
+    constType === SyntaxType.DoubleKeyword ||
+    constType === SyntaxType.I8Keyword ||
+    constType === SyntaxType.I16Keyword ||
+    constType === SyntaxType.I32Keyword ||
+    constType === SyntaxType.I64Keyword ||
+    constType === SyntaxType.ByteKeyword
+  ) {
+    cType = constType;
+    value = (c.initializer as IntConstant | DoubleConstant).value.value;
+  } else if (constType === SyntaxType.StringKeyword) {
+    cType = constType;
+    value = (c.initializer as StringLiteral).value;
+  } else {
+    return false;
+  }
+  let typeString = getFieldTypeString(c.fieldType, options);
+  if (typeString === 'Int64') {
+    typeString = 'string';
+  }
+
+  const name = c.name.value;
+  return {
+    type: cType as ConstantEntityType,
+    value,
+    name,
+    comments: c.comments,
+    loc: c.loc,
+    typeString
   };
 }
 

--- a/src/thriftNew/index.ts
+++ b/src/thriftNew/index.ts
@@ -191,6 +191,7 @@ function getFieldTypeString(
   options: Partial<CMDOptions> = {}
 ): string {
   const { i64Type = 'Int64' } = options;
+  const { mapType = 'Map' } = options;
   const ThriftType2JavascriptType: { [key: string]: string } = {
     [SyntaxType.BoolKeyword]: 'boolean',
     [SyntaxType.ByteKeyword]: 'number',
@@ -218,7 +219,13 @@ function getFieldTypeString(
     return `${getFieldTypeString(fieldType.valueType, options)}[]`;
   }
   if (fieldType.type === SyntaxType.MapType) {
-    return `Map<${getFieldTypeString(
+    if (mapType === 'Record') {
+      return `${mapType}<string, ${getFieldTypeString(
+        fieldType.valueType,
+        options
+      )}>`;
+    }
+    return `${mapType}<${getFieldTypeString(
       fieldType.keyType,
       options
     )}, ${getFieldTypeString(fieldType.valueType, options)}>`;

--- a/src/thriftNew/index.ts
+++ b/src/thriftNew/index.ts
@@ -190,7 +190,7 @@ function getFieldTypeString(
   fieldType: FunctionType,
   options: Partial<CMDOptions> = {}
 ): string {
-  const { i64Type = 'Int64' } = options;
+  const i64Type = 'Int64';
   const { mapType = 'Map' } = options;
   const ThriftType2JavascriptType: { [key: string]: string } = {
     [SyntaxType.BoolKeyword]: 'boolean',

--- a/src/thriftNew/interfaces.ts
+++ b/src/thriftNew/interfaces.ts
@@ -119,6 +119,7 @@ export interface CMDOptions {
   strictReq?: boolean;
   enumJson?: string;
   i64Type?: string;
+  mapType?: string;
 }
 
 export type PbNodeEntity = (

--- a/src/thriftNew/interfaces.ts
+++ b/src/thriftNew/interfaces.ts
@@ -28,8 +28,24 @@ export interface RpcEntity {
   interfaces: InterfaceEntity[];
   typeDefs: TypeDefEntity[];
   services: ServiceEntity[];
+  consts: ConstantEntity[];
 }
 
+// https://thrift.apache.org/docs/idl#constant-values 实际上可以是int，double，字符串字面量，const list，const map，先快速支持int和double
+export type ConstantEntityType =
+  | SyntaxType.ByteKeyword
+  | SyntaxType.DoubleKeyword
+  | SyntaxType.I8Keyword
+  | SyntaxType.I16Keyword
+  | SyntaxType.I32Keyword
+  | SyntaxType.I64Keyword
+  | SyntaxType.StringKeyword;
+export interface ConstantEntity extends PrimarySyntax {
+  name: string;
+  type: ConstantEntityType;
+  value: string;
+  typeString: string;
+}
 export interface EnumEntity extends PrimarySyntax {
   name: string;
   properties: {
@@ -102,6 +118,7 @@ export interface CMDOptions {
   annotationConfig?: IAnnotationConfig;
   strictReq?: boolean;
   enumJson?: string;
+  i64Type?: string;
 }
 
 export type PbNodeEntity = (

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -1,3 +1,31 @@
+import * as fs from 'fs-extra';
+
 export function isUndefined(v: any): v is undefined {
   return typeof v === 'undefined';
+}
+
+export function replaceTsHelperInt64(filePath: string) {
+  const strToReplace = `declare var Int64: {
+    prototype: Int64;
+    new (): Int64;
+};
+interface Int64 {
+    toString(): string;
+}
+declare type ReqNumber = number | string | Int64;
+declare type RespNumber = Int64;
+declare type WrapperReqNumber<T> = Int64 extends T ? ReqNumber : T extends number[] ? ReqNumber[] : T;
+declare type WrapperRespNumber<T> = T extends number ? RespNumber : T extends number[] ? RespNumber[] : T;`;
+  const newStr = `declare type Int64 = string
+declare type ReqNumber = number | string | Int64;
+declare type RespNumber = Int64;
+declare type WrapperReqNumber<T> = T;
+declare type WrapperRespNumber<T> = T;`;
+  fs.writeFileSync(
+    filePath,
+    fs
+      .readFileSync(filePath)
+      .toString()
+      .replace(strToReplace, newStr)
+  );
 }

--- a/test/thriftNew/examples/enumJson.thrift
+++ b/test/thriftNew/examples/enumJson.thrift
@@ -67,3 +67,9 @@ struct CollectRequest
 
 typedef Collection CollectResponse
 
+const i32 C32 = 1234
+const i64 C64 = 12345678
+const double CDouble = 1e3
+const string CString = '123123'
+const map<string,string> CMap = {"hello": "world", "goodnight": "moon"}
+const list<string> CList = ['hello', 'world']

--- a/test/thriftNew/print.test.ts
+++ b/test/thriftNew/print.test.ts
@@ -8,7 +8,8 @@ import {
   fixIncludeNamespace,
   printServices,
   printCollectionRpc,
-  printEnumsObject
+  printEnumsObject,
+  printConsts
 } from '../../src/thriftNew/print';
 import {
   TextLocation,
@@ -58,6 +59,7 @@ describe('thrift - print', () => {
     services: [],
     ns: '',
     fileName: '',
+    consts: [],
     enums: [
       {
         name: 'BizType',
@@ -294,6 +296,7 @@ biz_ext?: any;
     const rtn = printServices(
       {
         ns: 'test',
+        consts: [],
         includes: [],
         enums: [],
         typeDefs: [],
@@ -360,6 +363,7 @@ biz_ext?: any;
       {
         ns: 'l6',
         interfaces: [],
+        consts: [],
         typeDefs: [
           {
             alias: 'Input1',
@@ -434,7 +438,7 @@ export interface RpcService2 {
     expect(printServices(rtn).indexOf('WebFake()') !== -1).to.eq(true);
   });
 
-  it('parse enum json success', async () => {
+  it('print enum json success', async () => {
     const fileName = path.join(__dirname, 'examples', 'enumJson.thrift');
     const rtn = await readCode(fileName);
     const enums = printEnumsObject({ [fileName]: rtn });
@@ -443,9 +447,25 @@ export interface RpcService2 {
       'life.api_favorite.AizType.GOODS': 1,
       'life.api_favorite.BizType.ALL': 0,
       'life.api_favorite.BizType.GOODS': 1,
+      'life.api_favorite.C32': 1234,
+      'life.api_favorite.C64': '12345678',
+      'life.api_favorite.CDouble': 1000,
+      'life.api_favorite.CString': '123123',
       'life.api_favorite.ZizType.ALL': 0,
       'life.api_favorite.ZizType.GOODS': 1
     };
     expect(JSON.stringify(enums)).to.eq(JSON.stringify(enumObj));
+  });
+
+  it('print const success', async () => {
+    const fileName = path.join(__dirname, 'examples', 'enumJson.thrift');
+    const rtn = await readCode(fileName);
+    const consts = printConsts(rtn);
+    console.log(consts);
+    expect(consts).to.eq(`  export const C32 = 1234
+  export const C64 = '12345678'
+  export const CDouble = 1e3
+  export const CString = '123123'
+`);
   });
 });

--- a/test/thriftNew/readCode.test.ts
+++ b/test/thriftNew/readCode.test.ts
@@ -704,4 +704,48 @@ describe('thrift - read code file', () => {
     expect(collection.collectionD1.optional).to.eq(true);
     expect(collection.collectionD2.optional).to.eq(true);
   });
+
+  it('support i64 as string', async () => {
+    const thirftCodeJS = `
+      namespace js xx
+      struct X {
+        1: optional list<i64> myList,
+        1: optional i64 myI64,
+        1: optional map<i64, i64> myMap,
+        1: optional set<i64> mySet,
+        1: optional i32 myI32,
+      }
+      `;
+
+    const res = await parser('', thirftCodeJS, { i64Type: 'string' });
+    const struct = res.interfaces[0].properties;
+
+    expect(struct.myList.type).to.eq('string[]');
+    expect(struct.myI64.type).to.eq('string');
+    expect(struct.myMap.type).to.eq('Map<string, string>');
+    expect(struct.mySet.type).to.eq('Set<string>');
+    expect(struct.myI32.type).to.eq('number');
+  });
+
+  it('support numerical constant and string constant', async () => {
+    const thirftCodeJS = `
+      namespace js xx
+      const i32 C32 = 1234;
+      const i64 C64 = 12345678;
+      const double CDouble = 1e3;
+      const string CString = '123123';
+      const map<string,string> CMap = {"hello": "world", "goodnight": "moon"};
+      const list<string> CList = ['hello', 'world'];
+      `;
+
+    const res = await parser('', thirftCodeJS, { i64Type: 'string' });
+    const consts = res.consts;
+
+    expect(consts.length).to.equal(4);
+    expect(consts[0].value).to.equal('1234');
+    expect(consts[0].name).to.equal('C32');
+    expect(consts[1].value).to.equal('12345678');
+    expect(consts[2].value).to.equal('1e3');
+    expect(consts[3].value).to.equal('123123');
+  });
 });

--- a/test/thriftNew/readCode.test.ts
+++ b/test/thriftNew/readCode.test.ts
@@ -748,4 +748,20 @@ describe('thrift - read code file', () => {
     expect(consts[2].value).to.equal('1e3');
     expect(consts[3].value).to.equal('123123');
   });
+
+  it('support map as record', async () => {
+    const thirftCodeJS = `
+      namespace js xx
+      struct X {
+        1: optional map<i64, i64> myMap,
+      }
+      `;
+
+    const res = await parser('', thirftCodeJS, {
+      mapType: 'Record'
+    });
+    const struct = res.interfaces[0].properties;
+
+    expect(struct.myMap.type).to.eq('Record<string, Int64>');
+  });
 });


### PR DESCRIPTION
支持在 thrift 中把 i64 转换成 string 或者内置的 Int64 对象，在`--new`的同时通过`--i64`设置，默认生成 int64 类型。例如 i64 生成 string 类型

```shell
node ./bin/dts-from-thrift -p ./test/thriftNew/examples/ \
-o ./test/thriftNew/out/ \
--new --i64 string
```

支持把 thrift idl 中的 const 输出到 d.ts 和 enum.json 中，用于类型提示或者自定义 babel 插件。注意：d.ts 中的 const 在编译过程中并不会被转换。效果可以运行根目录下的 run.sh 来查看。

支持 thrift idl 中的 `map<typea, typeb>` 输出到 `Record<typea, typeb>`。注意：Record 对于 key 的支持只有 number,string,symbol，所以最好结合`--i64 string`使用。栗子：

```shell
node ./bin/dts-from-thrift -p ./test/thriftNew/examples/ \
-o ./test/thriftNew/out/ \
--new --i64 string --map Record
```