### PR TITLE
feat: support module output

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -48,6 +48,7 @@ commander
   .option('-e --entry [filename]', '指定入口文件名', 'index.d.ts')
   .option('--use-tag <tagName>', '使用 tag 名称替换 field 名称')
   .option('--prettier', '输出时使用 prettier 格式化', false)
+  .option('--module', '输出为module格式', false)
   .option(
     '--rpc-namespace <rpc-namespace>',
     '指定一个独立的 namespace 存放所有 service',
@@ -75,6 +76,7 @@ const options: CMDOptions = {
   useTimestamp: commander.timestamp,
   useTag: commander.useTag,
   usePrettier: commander.prettier,
+  useModule: commander.module,
   rpcNamespace: commander.rpcNamespace,
   lint: false,
   i64_as_number: false,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -83,6 +83,7 @@ export interface CMDOptions {
   entryName: string;
   useTag: string;
   usePrettier: boolean;
+  useModule: boolean;
   rpcNamespace: string;
   lint: boolean;
   i64_as_number: boolean;

--- a/src/thriftNew/interfaces.ts
+++ b/src/thriftNew/interfaces.ts
@@ -116,6 +116,7 @@ export interface CMDOptions {
   entryName: string;
   useTag: string;
   usePrettier: boolean;
+  useModule: boolean;
   rpcNamespace: string;
   lint: boolean;
   i64_as_number: boolean;

--- a/src/tools/combine.ts
+++ b/src/tools/combine.ts
@@ -26,7 +26,7 @@ export default function combine(options: Partial<CMDOptions> = {}) {
   const lines = files.map(f => {
     const relativePath = path.relative(options.tsRoot || process.cwd(), f);
     if (options.useModule)
-      return `export * from "${relativePath}";`;
+      return `export * from "./${relativePath.replace(/\.d\.ts$/, '')}";`;
     else 
       return `/// <reference path="${relativePath}" />`;
   });

--- a/src/tools/combine.ts
+++ b/src/tools/combine.ts
@@ -25,7 +25,10 @@ export default function combine(options: Partial<CMDOptions> = {}) {
 
   const lines = files.map(f => {
     const relativePath = path.relative(options.tsRoot || process.cwd(), f);
-    return `/// <reference path="${relativePath}" />`;
+    if (options.useModule)
+      return `export * from "${relativePath}";`;
+    else 
+      return `/// <reference path="${relativePath}" />`;
   });
 
   fs.writeFileSync(


### PR DESCRIPTION
Close #24 

Allowing new option "--module" to make the output in the module mode.

### Before
```ts
declare namespace "a.b.c" {
  export interface A {
    b: string
  }
}
```
index.d.ts
```ts
/// <reference path="foo.d.ts" />
/// <reference path="bar.d.ts" />
```

### After
```ts
export interface A {
  b: string
}
```
index.d.ts
```ts
export * from "foo.d.ts";
export * from "bar.d.ts";
```
