### PR TITLE
fix(namespace): handle . in fix namespace

### DIFF
--- a/src/thriftNew/print.ts
+++ b/src/thriftNew/print.ts
@@ -257,7 +257,7 @@ export function fixIncludeNamespace(
 
     result = result.replace(
       new RegExp(
-        `(\\W)((?<!__SEGMENT__.*)${shouldReplaceNS}\\.|${shouldReplaceNS}(?!.*__SEGMENT__)\\.)`,
+        `([^A-Za-z0-9\\.])((?<!__SEGMENT__.*)${shouldReplaceNS}\\.|${shouldReplaceNS}(?!.*__SEGMENT__)\\.)`,
         'g'
       ),
       `__SEGMENT__$1${shouldBeNS}__SEGMENT__.`

--- a/test/thriftNew/print.test.ts
+++ b/test/thriftNew/print.test.ts
@@ -254,11 +254,16 @@ export interface BizRequest {
   });
 
   it('fixIncludeNamespace success with nest path', () => {
-    const res = fixIncludeNamespace(
-      `interface interface1 {
+    // 这里是基于字符串的替换，在识别的时候，如果前面有"."，如果life.item.demo，item也不应该被替换
+    let res = fixIncludeNamespace(
+      `
+    declare namespace life.item.demo {
+      interface interface1 {
         data: list<detail.PackedItem>;
-        sort: item.SortType
-      }`,
+        sort: item.SortType;
+      }
+    }
+      `,
       {
         enums: [],
         fileName: '/test/root/demo.thrift',
@@ -289,10 +294,16 @@ export interface BizRequest {
         },
       }
     );
-    expect(res).not.eq(`interface interface1 {
-      data: list<life.item.detail.PackedItem>;
-      sort: life.demo.item.SortType
-    }`);
+    res = res.replace('// prettier-ignore', '').replace(/\s+/g, '');
+    expect(res).eq(
+      `
+    declare namespace life.item.demo {
+      interface interface1 {
+        data: list<life.item.detail.PackedItem>;
+        sort: life.demo.item.SortType;
+      }
+    }`.replace(/\s+/g, '')
+    );
   });
 
   it('printService success', () => {


### PR DESCRIPTION
fixIncludeNamespace是基于字符串的替换，在识别的时候，如果前面有"."，如果life.item.demo，item也不应该被替换
```js
it('fixIncludeNamespace success with nest path', () => {
    // 这里是基于字符串的替换，在识别的时候，如果前面有"."，如果life.item.demo，item也不应该被替换
    let res = fixIncludeNamespace(
      `
    declare namespace life.item.demo {
      interface interface1 {
        data: list<detail.PackedItem>;
        sort: item.SortType;
      }
    }
      `,
      {
        enums: [],
        fileName: '/test/root/demo.thrift',
        includes: ['/test/root/detail.thrift', '/test/root/item.thrift'],
        ns: 'life.demo',
        interfaces: [],
        typeDefs: [],
        services: [],
      },
      {
        '/test/root/detail.thrift': {
          enums: [],
          services: [],
          fileName: '/test/root/detail.thrift',
          includes: [],
          ns: 'life.item.detail',
          interfaces: [],
          typeDefs: [],
        },
        '/test/root/item.thrift': {
          enums: [],
          services: [],
          fileName: '/test/root/item.thrift',
          includes: [],
          ns: 'life.demo.item',
          interfaces: [],
          typeDefs: [],
        },
      }
    );
    res = res.replace('// prettier-ignore', '').replace(/\s+/g, '');
    expect(res).eq(
      `
    declare namespace life.item.demo {
      interface interface1 {
        data: list<life.item.detail.PackedItem>;
        sort: life.demo.item.SortType;
      }
    }`.replace(/\s+/g, '')
    );
  });
```