### PR TITLE
Fix the regexp matches unexpected substring in reserved word replacer

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint": "^7.18.0",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
-    "ts-node": "^9.1.1",
+    "ts-node": "^10.9.1",
     "typescript": "^4.1.3"
   },
   "dependencies": {

--- a/src/thriftNew/@creditkarma/thrift-parser/parser.ts
+++ b/src/thriftNew/@creditkarma/thrift-parser/parser.ts
@@ -1211,7 +1211,7 @@ export function createParser(
 
 
     const ReservedWordsForIdentifierRegExp = new RegExp(
-        `\\.?${RESERVEDWORDS.map((v) => `(${v})`).join('|')}\\.?`,
+        `(?<=\\.|^)(?:${RESERVEDWORDS.map((v) => `(${v})`).join('|')})(?=\\.|$)`,
         'g'
     );
 

--- a/test/thriftNew/examples/reserved_word.thrift
+++ b/test/thriftNew/examples/reserved_word.thrift
@@ -1,0 +1,5 @@
+namespace go reserved_word.enum
+
+struct debugger {
+    1: i64 id
+}

--- a/test/thriftNew/examples/reserved_word_test.thrift
+++ b/test/thriftNew/examples/reserved_word_test.thrift
@@ -1,0 +1,7 @@
+include "./reserved_word.thrift"
+
+namespace go if.const.letenum.if.enum_d.enum_if.enum0.enum
+
+struct do {
+    1: reserved_word.enum.debugger debugger
+}

--- a/test/thriftNew/readCode.test.ts
+++ b/test/thriftNew/readCode.test.ts
@@ -778,4 +778,15 @@ describe('thrift - read code file', () => {
 
     expect(struct.myMap.type).to.eq('Record<string, Int64>');
   });
+
+  it('support reserved word', async () => {
+    const res = await readCode(
+      path.resolve(__dirname, './examples/reserved_word_test.thrift'),
+      { reservedWord: 'escape' }
+    );
+
+    expect(res.ns).to.eq('If.Const.letenum.If.enum_d.enum_if.enum0.Enum');
+    expect(res.interfaces[0].properties).to.have.property('debugger');
+    expect(res.interfaces[0].properties.debugger.type).to.eq('reserved_word.Enum.Debugger');
+  });
 });


### PR DESCRIPTION
1. Fix the regexp matches unexpected substring in reserved word replacer
2. Add the unit test for reserved word feature.
